### PR TITLE
Updated onnxruntime to 1.7.0 versions

### DIFF
--- a/chapter4/packaging-containers/requirements.txt
+++ b/chapter4/packaging-containers/requirements.txt
@@ -3,4 +3,4 @@ tensorboardX==1.9
 transformers==2.1.0
 flask==1.1.2
 torch==1.7.1
-onnxruntime==1.6.0
+onnxruntime==1.7.0


### PR DESCRIPTION
ERROR: Could not find a version that satisfies the requirement onnxruntime==1.6.0 (from versions: 1.7.0, 1.8.0, 1.8.1, 1.9.0, 1.10.0, 1.11.0, 1.11.1)
ERROR: No matching distribution found for onnxruntime==1.6.0